### PR TITLE
Require a minimum buzzer hold time before notifying recipients

### DIFF
--- a/dingdongditch/action.py
+++ b/dingdongditch/action.py
@@ -45,7 +45,7 @@ UNIT_1 = UNIT_2 = None
 if settings.UNIT_1.id:
     UNIT_1 = Unit(
         id=settings.UNIT_1.id,
-        buzzer=Button(settings.UNIT_1.buzzer),
+        buzzer=Button(pin=settings.UNIT_1.buzzer, hold_time=settings.BUZZER_HOLD),
         bell=Bell(settings.UNIT_1.bell),
         strike=Strike.get(settings.UNIT_1.strike)
     )
@@ -53,7 +53,7 @@ if settings.UNIT_1.id:
 if settings.UNIT_2.id:
     UNIT_2 = Unit(
         id=settings.UNIT_2.id,
-        buzzer=Button(settings.UNIT_2.buzzer),
+        buzzer=Button(pin=settings.UNIT_2.buzzer, hold_time=settings.BUZZER_HOLD),
         bell=Bell(settings.UNIT_2.bell),
         strike=Strike.get(settings.UNIT_2.strike)
     )

--- a/dingdongditch/system_settings.py
+++ b/dingdongditch/system_settings.py
@@ -55,6 +55,13 @@ FROM_NUMBER = Env.string('DDD_FROM_NUMBER')
 ## Hardware Interface
 ##
 
+# The throttle rate of the doorbell trigger, in seconds.
+BUZZER_INTERVAL = Env.number('DDD_BUZZER_INTERVAL', 15)
+
+# The time (in seconds) to wait after the buzzer is pushed to notify recipients.
+BUZZER_HOLD = Env.number('DDD_BUZZER_HOLD', 0.2)
+
+
 ##
 ## Unit 1
 ##

--- a/dingdongditch/trigger.py
+++ b/dingdongditch/trigger.py
@@ -5,9 +5,9 @@ import signal
 
 import blinker
 
-from . import action, notifier, user_settings
+from . import action, notifier, system_settings, user_settings
 
-WINDOW = datetime.timedelta(seconds=15)
+WINDOW = datetime.timedelta(seconds=system_settings.BUZZER_INTERVAL)
 logger = logging.getLogger(__name__)
 
 
@@ -69,14 +69,14 @@ def handle_gate_strike_unit_2(sender, value=None):
 
 
 if action.UNIT_1:
-    action.UNIT_1.buzzer.when_pressed = trigger_unit_1
+    action.UNIT_1.buzzer.when_held = trigger_unit_1
     blinker.signal(
         get_strike_setting_path(action.UNIT_1.id)
     ).connect(handle_gate_strike_unit_1)
 
 
 if action.UNIT_2:
-    action.UNIT_2.buzzer.when_pressed = trigger_unit_2
+    action.UNIT_2.buzzer.when_held = trigger_unit_2
     blinker.signal(
         get_strike_setting_path(action.UNIT_2.id)
     ).connect(handle_gate_strike_unit_2)


### PR DESCRIPTION
This may eliminate erroneous triggers from noisy buzzers.