### PR TITLE
Attempt to recover from a dropped user settings stream connection

### DIFF
--- a/dingdongditch/exceptions.py
+++ b/dingdongditch/exceptions.py
@@ -1,0 +1,2 @@
+class StaleData(ValueError):
+    """Exception raised when data is stale."""

--- a/dingdongditch/firebase_user_settings_adapter.py
+++ b/dingdongditch/firebase_user_settings_adapter.py
@@ -42,7 +42,7 @@ def _get_path_list(path):
 
 class FirebaseData(dict):
     last_updated_at = None
-    data_ttl = datetime.timedelta(hours=2)
+    data_ttl = datetime.timedelta(hours=1)
 
     def __init__(self, *args, **kwargs):
         self.last_updated_at = datetime.datetime.utcnow()

--- a/dingdongditch/firebase_user_settings_adapter.py
+++ b/dingdongditch/firebase_user_settings_adapter.py
@@ -1,11 +1,13 @@
 import atexit
 import collections
+import datetime
 import logging
 
 from blinker import signal
 import pyrebase
 
 from . import system_settings as settings
+from .exceptions import StaleData
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +41,13 @@ def _get_path_list(path):
 
 
 class FirebaseData(dict):
+    last_updated_at = None
+    data_ttl = datetime.timedelta(hours=2)
+
+    def __init__(self, *args, **kwargs):
+        self.last_updated_at = datetime.datetime.utcnow()
+        super().__init__(*args, **kwargs)
+
     def get_node_for_path(self, path):
         keys = _get_path_list(path)
         node = self
@@ -86,6 +95,8 @@ class FirebaseData(dict):
                 del node.parent[node.key]
             else:
                 node.parent[node.key] = data
+
+        self.last_updated_at = datetime.datetime.utcnow()
         signal(path).send(self, value=data)
 
     def merge(self, path, data):
@@ -103,10 +114,28 @@ class FirebaseData(dict):
                 return None
         return node
 
+    @property
+    def is_stale(self):
+        if not self.last_updated_at:
+            return True
+
+        return datetime.datetime.utcnow() - self.last_updated_at > self.data_ttl
+
 
 def get_settings():
     try:
-        return _cache['user_settings']
+        settings = _cache['user_settings']
+        if settings.is_stale:
+            logger.warning(
+                'Stale data found. Last update was %s',
+                settings.last_updated_at
+            )
+            raise StaleData(
+                'Firebase user data last updated at {}'.format(
+                    settings.last_updated_at
+                )
+            )
+        return settings
     except KeyError:
         # Fetch settings now
         _cache['user_settings'] = FirebaseData(db.child('settings').get().val())
@@ -150,7 +179,14 @@ def set_data(path, data, root='settings'):
     child.set(data)
 
 
+def reset():
+    logger.debug('Resetting all data')
+    hangup()
+    _cache.clear()
+
+
 @atexit.register
 def hangup():
+    logger.debug('Closing all streams')
     for stream in _streams.values():
         stream.close()

--- a/dingdongditch/user_settings.py
+++ b/dingdongditch/user_settings.py
@@ -6,6 +6,7 @@ import pickle
 
 from . import system_settings as settings
 from . import firebase_user_settings_adapter
+from .exceptions import StaleData
 
 ADAPTERS = {
     'firebase': firebase_user_settings_adapter
@@ -29,6 +30,11 @@ def get_data():
 
     try:
         data = adapter.get_settings()
+    except StaleData:
+        logger.debug('Stale data returned from adapter "%s." Resetting.', adapter.NAME)
+        adapter.reset()
+        init_user_data()
+        return get_data()
     except Exception as e:
         logger.exception(
             'Could not load user settings from adapter "%s": %s', adapter.NAME, e

--- a/tests/test_firebase_user_settings_adapter.py
+++ b/tests/test_firebase_user_settings_adapter.py
@@ -167,13 +167,13 @@ class TestFirebaseData_staleness:
 
     def test_is_stale__is_stale(self):
         data = user_settings.FirebaseData()
-        data.last_updated_at = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
+        data.last_updated_at = datetime.datetime.utcnow() - datetime.timedelta(hours=2)
 
         assert data.is_stale
 
     def test_is_stale__is_not_stale_after_update(self):
         data = user_settings.FirebaseData()
-        data.last_updated_at = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
+        data.last_updated_at = datetime.datetime.utcnow() - datetime.timedelta(hours=2)
 
         data.set('foo', 'bar')
         assert not data.is_stale

--- a/tests/test_firebase_user_settings_adapter.py
+++ b/tests/test_firebase_user_settings_adapter.py
@@ -1,7 +1,11 @@
+import datetime
+
 import blinker
 import pytest
 
 from dingdongditch import firebase_user_settings_adapter as user_settings
+from dingdongditch.exceptions import StaleData
+
 
 class Test_get_path_list:
     def test_no_path(self):
@@ -143,6 +147,38 @@ class TestFirebaseData_pubsub:
         listen_mock.assert_called_with(data, value=2)
 
 
+class TestFirebaseData_staleness:
+    def test_last_updated_at__set_on_init(self):
+        data = user_settings.FirebaseData()
+
+        assert isinstance(data.last_updated_at, datetime.datetime)
+
+
+    def test_last_updated_at__somehow_missing(self):
+        data = user_settings.FirebaseData()
+        data.last_updated_at = None
+
+        assert data.is_stale
+
+    def test_is_stale__is_not_stale(self):
+        data = user_settings.FirebaseData()
+
+        assert not data.is_stale
+
+    def test_is_stale__is_stale(self):
+        data = user_settings.FirebaseData()
+        data.last_updated_at = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
+
+        assert data.is_stale
+
+    def test_is_stale__is_not_stale_after_update(self):
+        data = user_settings.FirebaseData()
+        data.last_updated_at = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
+
+        data.set('foo', 'bar')
+        assert not data.is_stale
+
+
 class Test_get_settings:
     def test_cold_cache(self, mocker):
         listen_mock = mocker.patch('dingdongditch.firebase_user_settings_adapter.listen')
@@ -154,16 +190,23 @@ class Test_get_settings:
         assert isinstance(result, user_settings.FirebaseData)
 
     def test_warm_cache(self, mocker):
-        mock_settings = {}
+        mock_settings = mocker.MagicMock(is_stale=False)
         user_settings._cache['user_settings'] = mock_settings
 
         result = user_settings.get_settings()
 
         assert result is mock_settings
 
+    def test_stale_cache(self, mocker):
+        mock_settings = mocker.MagicMock(is_stale=True)
+        user_settings._cache['user_settings'] = mock_settings
+
+        with pytest.raises(StaleData):
+            user_settings.get_settings()
+
 
 def test_put_settings_handler(mocker):
-    mock_settings = mocker.MagicMock()
+    mock_settings = mocker.MagicMock(is_stale=False)
     user_settings._cache['user_settings'] = mock_settings
 
     path = '/foo/bar'
@@ -174,7 +217,7 @@ def test_put_settings_handler(mocker):
 
 
 def test_patch_settings_handler(mocker):
-    mock_settings = mocker.MagicMock()
+    mock_settings = mocker.MagicMock(is_stale=False)
     user_settings._cache['user_settings'] = mock_settings
 
     path = '/'
@@ -222,3 +265,26 @@ def test_stream_handler__patch(mocker):
     user_settings._stream_handler(message)
 
     patch_handler_mock.assert_called_with(message['path'], message['data'])
+
+
+def test_hangup(mocker):
+    streams = {
+        'user_settings': mocker.Mock(),
+        'user_settings2': mocker.Mock(),
+    }
+    mocker.patch('dingdongditch.firebase_user_settings_adapter._streams', streams)
+
+    user_settings.hangup()
+
+    assert streams['user_settings'].close.called
+    assert streams['user_settings2'].close.called
+
+
+def test_reset(mocker):
+    hangup = mocker.patch('dingdongditch.firebase_user_settings_adapter.hangup')
+    _cache = mocker.patch('dingdongditch.firebase_user_settings_adapter._cache')
+
+    user_settings.reset()
+
+    assert hangup.called
+    assert _cache.clear.called

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dingdongditch import user_settings, firebase_user_settings_adapter
+from dingdongditch.exceptions import StaleData
 
 
 @pytest.fixture
@@ -43,6 +44,18 @@ def test_get_data__valid(adapter):
     user_settings.get_data()
 
     assert adapter.get_settings.called
+
+
+def test_get_data__stale(adapter, mocker):
+    init_user_data = mocker.patch('dingdongditch.user_settings.init_user_data')
+    data = {}
+    adapter.get_settings.side_effect = [StaleData, data]
+
+    result = user_settings.get_data()
+
+    assert adapter.reset.called
+    assert init_user_data.called
+    assert result is data
 
 
 def test_set_data__error(adapter, mocker):


### PR DESCRIPTION
A healthy stream connection should refresh data every hour or so. If cached data is older than that, we can assume that the connection to Firebase Realtime Database has been dropped, and so we should attempt to reconnect, and refresh user settings data.