### PR TITLE
Cancel watchers before resetting data

### DIFF
--- a/dingdongditch/user_settings.py
+++ b/dingdongditch/user_settings.py
@@ -73,6 +73,7 @@ def init_data():
 
 
 def reset():
+    watcher.cancel()
     adapter = get_adapter()
     logger.debug(
         'Resetting adapter "%s."',

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -130,9 +130,11 @@ def test_init_data(mocker):
 
 def test_reset(mocker, adapter, get_data):
     init_user_data = mocker.patch('dingdongditch.user_settings.init_user_data')
+    cancel = mocker.patch('dingdongditch.watcher.cancel')
 
     user_settings.reset()
 
+    assert cancel.called
     assert adapter.reset.called
     assert init_user_data.called
     assert get_data.called


### PR DESCRIPTION
Fix bug allowing old watchers to continue to run.