### PR TITLE
Fallback to ringing the normal bell if the network is down

### DIFF
--- a/dingdongditch/system_settings.py
+++ b/dingdongditch/system_settings.py
@@ -61,6 +61,9 @@ BUZZER_INTERVAL = Env.number('DDD_BUZZER_INTERVAL', 30)
 # The time (in seconds) to wait after the buzzer is pushed to notify recipients.
 BUZZER_HOLD = Env.number('DDD_BUZZER_HOLD', 0.3)
 
+# Whether to always ring the bell, regardless of user setting, when the network is down
+RING_FALLBACK = Env.boolean('DDD_RING_FALLBACK', True)
+
 
 ##
 ## Unit 1

--- a/dingdongditch/utils.py
+++ b/dingdongditch/utils.py
@@ -12,8 +12,14 @@ class Env(object):
 
     @classmethod
     def number(cls, name, default=0):
+        val = cls.raw(name, default)
         try:
-            return int(cls.raw(name, default))
+            try:
+                if '.' in val:
+                    return float(val)
+                raise TypeError('Not a float')
+            except TypeError:
+                return int(val)
         except ValueError:
             return default
 
@@ -24,6 +30,6 @@ class Env(object):
         if value is None:
             return default
 
-        if value in ('0', 'false', 'False', 'off', 'no'):
+        if value in ('', '0', 'false', 'False', 'off', 'no'):
             return False
         return True

--- a/env.sh.example
+++ b/env.sh.example
@@ -34,6 +34,10 @@
 ## needed, just leave those settings commented out.
 ##
 
+# export DDD_BUZZER_INTERVAL=30
+# export DDD_BUZZER_HOLD=0.2
+# export DDD_RING_FALLBACK=true
+
 ##
 ## Unit 1 (required)
 ##

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -137,7 +137,6 @@ def test_reset(mocker, adapter, get_data):
     assert cancel.called
     assert adapter.reset.called
     assert init_user_data.called
-    assert get_data.called
 
 
 def test_get_unit_by_id__missing_data(get_data):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,103 @@
+import pytest
+
+from dingdongditch.utils import Env
+
+
+@pytest.fixture
+def getenv(mocker):
+    return mocker.patch('os.getenv')
+
+
+def test_raw__with_env(getenv):
+    getenv.return_value = 'baz'
+
+    result = Env.raw('foo')
+
+    getenv.assert_called_with('foo', None)
+    assert result == 'baz'
+
+
+def test_raw__with_default(getenv):
+    result = Env.raw('foo', 'bar')
+
+    getenv.assert_called_with('foo', 'bar')
+
+
+def test_string(getenv):
+    getenv.return_value = 'foo'
+
+    result = Env.string('FOO')
+
+    assert result == 'foo'
+
+
+def test_number__int(getenv):
+    getenv.return_value = '1234'
+
+    result = Env.number('FOO')
+
+    assert result == 1234
+
+
+def test_number__float(getenv):
+    getenv.return_value = '1234.5678'
+
+    result = Env.number('FOO')
+
+    assert result == 1234.5678
+
+
+def test_number__boolean__string(getenv):
+    getenv.return_value = 'foo'
+
+    result = Env.boolean('FOO')
+
+    assert result is True
+
+
+def test_number__boolean__empty(getenv):
+    getenv.return_value = ''
+
+    result = Env.boolean('FOO')
+
+    assert result is False
+
+
+def test_number__boolean__0(getenv):
+    getenv.return_value = '0'
+
+    result = Env.boolean('FOO')
+
+    assert result is False
+
+
+def test_number__boolean__false(getenv):
+    getenv.return_value = 'false'
+
+    result = Env.boolean('FOO')
+
+    assert result is False
+
+
+def test_number__boolean__False(getenv):
+    getenv.return_value = 'False'
+
+    result = Env.boolean('FOO')
+
+    assert result is False
+
+
+def test_number__boolean__off(getenv):
+    getenv.return_value = 'off'
+
+    result = Env.boolean('FOO')
+
+    assert result is False
+
+
+def test_number__boolean__no(getenv):
+    getenv.return_value = 'no'
+
+    result = Env.boolean('FOO')
+
+    assert result is False


### PR DESCRIPTION
If all notification attempts have failed, and the settings allow it, ring the normal doorbell.