### PR TITLE
Track open streams better

### DIFF
--- a/dingdongditch/user_settings.py
+++ b/dingdongditch/user_settings.py
@@ -64,7 +64,7 @@ def init_user_data():
         set_data(path, 0)
 
     data = get_data()
-    watcher.watch(lambda: data.is_stale, reset)
+    watcher.watch(id(data), data.is_stale, reset)
     return data
 
 
@@ -74,12 +74,13 @@ def init_data():
 
 
 def reset():
-    watcher.cancel()
+    data = get_data()
     adapter = get_adapter()
     logger.debug(
         'Resetting adapter "%s."',
         adapter.NAME
     )
+    watcher.cancel(id(data))
     adapter.reset()
     return init_user_data()
 

--- a/dingdongditch/watcher.py
+++ b/dingdongditch/watcher.py
@@ -9,7 +9,7 @@ _timers = {}
 logger = logging.getLogger(__name__)
 
 
-def watch(should_update, update_func, interval=DEFAULT_INTERVAL):
+def watch(name, should_update, update_func, interval=DEFAULT_INTERVAL):
     """Watch something and call a function when it should be updated.
 
     Arguments:
@@ -25,7 +25,7 @@ def watch(should_update, update_func, interval=DEFAULT_INTERVAL):
 
     def start():
         logger.debug('Checking if update is required: %s', should_update)
-        _timers[update_func] = t = Timer(interval.total_seconds(), action)
+        _timers[name] = t = Timer(interval.total_seconds(), action)
         t.start()
 
     def action():
@@ -36,6 +36,13 @@ def watch(should_update, update_func, interval=DEFAULT_INTERVAL):
 
     start()
     return cancel
+
+
+def cancel(name):
+    watcher = _timers.get(name)
+    if watcher:
+        watcher.cancel()
+    del _timers[name]
 
 
 @atexit.register

--- a/dingdongditch/watcher.py
+++ b/dingdongditch/watcher.py
@@ -45,7 +45,7 @@ def cancel(name):
 
 
 @atexit.register
-def cancel():
+def cancel_all():
     logger.debug('Stopping all watchers')
     for timer in _timers.values():
         timer.cancel()

--- a/dingdongditch/watcher.py
+++ b/dingdongditch/watcher.py
@@ -35,7 +35,6 @@ def watch(name, should_update, update_func, interval=DEFAULT_INTERVAL):
         start()
 
     start()
-    return cancel
 
 
 def cancel(name):

--- a/tests/test_firebase_user_settings_adapter.py
+++ b/tests/test_firebase_user_settings_adapter.py
@@ -156,25 +156,25 @@ class TestFirebaseData_staleness:
         data = user_settings.FirebaseData()
         data.last_updated_at = None
 
-        assert data.is_stale
+        assert data.is_stale()
 
     def test_is_stale__is_not_stale(self):
         data = user_settings.FirebaseData()
 
-        assert not data.is_stale
+        assert not data.is_stale()
 
     def test_is_stale__is_stale(self):
         data = user_settings.FirebaseData()
         data.last_updated_at = datetime.datetime.utcnow() - datetime.timedelta(hours=2)
 
-        assert data.is_stale
+        assert data.is_stale()
 
     def test_is_stale__is_not_stale_after_update(self):
         data = user_settings.FirebaseData()
         data.last_updated_at = datetime.datetime.utcnow() - datetime.timedelta(hours=2)
 
         data.set('foo', 'bar')
-        assert not data.is_stale
+        assert not data.is_stale()
 
 
 def test_FirebaseData_repr():
@@ -284,7 +284,6 @@ def test_hangup(mocker):
     user_settings.hangup()
 
     _gc_streams.put.assert_called_with(stream)
-    assert streams.clear.called
     assert _gc_streams.join.called
 
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,10 +1,118 @@
 from datetime import timedelta
 import time
 
+import pytest
+
 from dingdongditch import watcher
 
 
-def test_watcher__not_stale(mocker):
+@pytest.fixture
+def timer_fake(mocker):
+    return  mocker.patch('dingdongditch.watcher.Timer')
+
+
+@pytest.fixture
+def watcher_stub(mocker, timer_fake):
+    is_stale = mocker.Mock()
+    update = mocker.Mock()
+    interval = timedelta(seconds=.001)
+    return watcher.Watcher(is_stale, update, interval)
+
+
+def test_Watcher_init(watcher_stub, timer_fake):
+    assert watcher_stub.running is False
+    assert not timer_fake.called
+
+
+def test_Watcher_start(watcher_stub, timer_fake):
+    watcher_stub.start()
+
+    assert watcher_stub.should_cancel is False
+    assert watcher_stub.running is True
+    assert timer_fake.called
+    assert timer_fake.return_value.start.called
+
+
+def test_Watcher_cancel(watcher_stub):
+    watcher_stub.cancel()
+
+    assert watcher_stub.should_cancel is True
+
+
+def test_Watcher_action__not_stale(mocker, watcher_stub):
+    watcher_stub.should_update.return_value = False
+    watcher_stub.start = mocker.Mock()
+    watcher_stub.should_cancel = False
+    watcher_stub._action()
+
+    assert watcher_stub.should_update.called
+    assert not watcher_stub.update_func.called
+    assert watcher_stub.start.called
+
+
+def test_Watcher_action__stale(mocker, watcher_stub):
+    watcher_stub.should_update.return_value = True
+    watcher_stub.start = mocker.Mock()
+    watcher_stub.should_cancel = False
+    watcher_stub._action()
+
+    assert watcher_stub.should_update.called
+    assert watcher_stub.update_func.called
+    assert watcher_stub.start.called
+
+
+def test_Watcher_action__should_cancel(mocker, watcher_stub):
+    watcher_stub.start = mocker.Mock()
+    watcher_stub.should_cancel = True
+    watcher_stub._action()
+
+    assert not watcher_stub.should_update.called
+    assert not watcher_stub.update_func.called
+    assert not watcher_stub.start.called
+
+
+def test_watch(mocker):
+    watcher_stub = mocker.patch('dingdongditch.watcher.Watcher')
+    is_stale = mocker.Mock()
+    update = mocker.Mock()
+    interval = timedelta(seconds=.001)
+
+    watcher.watch('test_watcher', is_stale, update, interval)
+
+    watcher_stub.assert_called_with(is_stale, update, interval)
+    assert watcher_stub.return_value.start.called
+    assert 'test_watcher' in watcher._watchers
+
+
+def test_cancel__unknown_name(mocker):
+    result = watcher.cancel('whatever')
+
+    assert result is None
+
+
+def test_cancel__known_name(mocker):
+    watcher_stub = mocker.Mock()
+    watcher._watchers['something'] = watcher_stub
+    result = watcher.cancel('something')
+
+    assert result is True
+    assert watcher_stub.cancel.called
+
+
+def test_cancel_all(mocker):
+    watcher_stub1 = mocker.Mock()
+    watcher_stub2 = mocker.Mock()
+    watcher._watchers['watcher1'] = watcher_stub1
+    watcher._watchers['watcher2'] = watcher_stub2
+
+    watcher.cancel_all()
+
+    assert watcher_stub1.cancel.called
+    assert watcher_stub2.cancel.called
+    assert not watcher._watchers
+
+
+def test_watch__not_stale(mocker):
     is_stale = mocker.Mock()
     is_stale.side_effect = [
         False,
@@ -20,7 +128,7 @@ def test_watcher__not_stale(mocker):
     assert update.called is False
 
 
-def test_watcher__stale(mocker):
+def test_watch__stale(mocker):
     is_stale = mocker.Mock()
     is_stale.side_effect = [
         False,

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -13,7 +13,7 @@ def test_watcher__not_stale(mocker):
     ]
     update = mocker.Mock()
     interval = timedelta(seconds=.001)
-    cancel = watcher.watch(is_stale, update, interval)
+    cancel = watcher.watch('test_watcher', is_stale, update, interval)
     time.sleep(.1)
     cancel()
     assert is_stale.call_count == 4
@@ -29,7 +29,7 @@ def test_watcher__stale(mocker):
     ]
     update = mocker.Mock()
     interval = timedelta(seconds=.001)
-    cancel = watcher.watch(is_stale, update, interval)
+    cancel = watcher.watch('test_watcher', is_stale, update, interval)
     time.sleep(.1)
     cancel()
     assert is_stale.call_count == 4

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -13,9 +13,9 @@ def test_watcher__not_stale(mocker):
     ]
     update = mocker.Mock()
     interval = timedelta(seconds=.001)
-    cancel = watcher.watch('test_watcher', is_stale, update, interval)
+    watcher.watch('test_watcher', is_stale, update, interval)
     time.sleep(.1)
-    cancel()
+    watcher.cancel('test_watcher')
     assert is_stale.call_count == 4
     assert update.called is False
 
@@ -29,8 +29,8 @@ def test_watcher__stale(mocker):
     ]
     update = mocker.Mock()
     interval = timedelta(seconds=.001)
-    cancel = watcher.watch('test_watcher', is_stale, update, interval)
+    watcher.watch('test_watcher', is_stale, update, interval)
     time.sleep(.1)
-    cancel()
+    watcher.cancel('test_watcher')
     assert is_stale.call_count == 4
     assert update.called is True


### PR DESCRIPTION
Track streams by name, so that references to streams are not lost if they do not shut down properly.