### PR TITLE
Allow strike open duration to be customized via env var

### DIFF
--- a/dingdongditch/action.py
+++ b/dingdongditch/action.py
@@ -10,13 +10,16 @@ class Strike(DigitalOutputDevice):
     """A class to represent an electronic gate strike."""
     _instances = {}
 
-    def release(self, duration=3):
+    DEFAULT_DURATION = 3
+
+    def release(self, duration=None):
         """Release the strike, thus opening the door/gate it is guarding.
 
         Arguments:
-            duration: The duration that the strike should remain open.
+            duration: The duration that the strike should remain open, in seconds.
         """
-        super(Strike, self).blink(on_time=duration, off_time=1, n=1, background=True)
+        on_time = duration or self.DEFAULT_DURATION
+        super(Strike, self).blink(on_time=on_time, off_time=1, n=1, background=True)
 
     @classmethod
     def get(cls, pin=None, *args, **kwargs):

--- a/dingdongditch/system_settings.py
+++ b/dingdongditch/system_settings.py
@@ -64,6 +64,9 @@ BUZZER_HOLD = Env.number('DDD_BUZZER_HOLD', 0.3)
 # Whether to always ring the bell, regardless of user setting, when the network is down
 RING_FALLBACK = Env.boolean('DDD_RING_FALLBACK', True)
 
+# The duration the strike should stay open when released, in seconds.
+STRIKE_RELEASE_DURATION = Env.number('DDD_STRIKE_RELEASE_DURATION', 3)
+
 
 ##
 ## Unit 1

--- a/dingdongditch/trigger.py
+++ b/dingdongditch/trigger.py
@@ -56,7 +56,7 @@ def handle_gate_strike_unit_1(sender, value=None):
     if not value:
         return
     logger.info('Gate strike activated for unit 1')
-    action.UNIT_1.strike.release()
+    action.UNIT_1.strike.release(system_settings.STRIKE_RELEASE_DURATION)
     user_settings.set_data(get_strike_setting_path(action.UNIT_1.id), 0)
 
 
@@ -64,7 +64,7 @@ def handle_gate_strike_unit_2(sender, value=None):
     if not value:
         return
     logger.info('Gate strike activated for unit 2')
-    action.UNIT_2.strike.release()
+    action.UNIT_2.strike.release(system_settings.STRIKE_RELEASE_DURATION)
     user_settings.set_data(get_strike_setting_path(action.UNIT_2.id), 0)
 
 

--- a/env.sh.example
+++ b/env.sh.example
@@ -37,6 +37,7 @@
 # export DDD_BUZZER_INTERVAL=30
 # export DDD_BUZZER_HOLD=0.2
 # export DDD_RING_FALLBACK=true
+# export DDD_STRIKE_RELEASE_DURATION=3
 
 ##
 ## Unit 1 (required)

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,3 +1,5 @@
+from gpiozero import DigitalOutputDevice
+
 from dingdongditch import action
 
 
@@ -14,3 +16,35 @@ class TestStrike:
         instance1 = action.Strike.get(1)
         instance2 = action.Strike.get(1)
         assert instance1 is instance2
+
+    def test_release__default(self, mocker):
+        instance = action.Strike(1)
+        blink_mock = mocker.patch.object(DigitalOutputDevice, 'blink', create=True)
+
+        instance.release()
+
+        blink_mock.assert_called_with(on_time=3, off_time=1, n=1, background=True)
+
+    def test_release__zero(self, mocker):
+        instance = action.Strike(1)
+        blink_mock = mocker.patch.object(DigitalOutputDevice, 'blink', create=True)
+
+        instance.release(0)
+
+        blink_mock.assert_called_with(on_time=3, off_time=1, n=1, background=True)
+
+    def test_release__none(self, mocker):
+        instance = action.Strike(1)
+        blink_mock = mocker.patch.object(DigitalOutputDevice, 'blink', create=True)
+
+        instance.release(None)
+
+        blink_mock.assert_called_with(on_time=3, off_time=1, n=1, background=True)
+
+    def test_release__custom(self, mocker):
+        instance = action.Strike(1)
+        blink_mock = mocker.patch.object(DigitalOutputDevice, 'blink', create=True)
+
+        instance.release(10)
+
+        blink_mock.assert_called_with(on_time=10, off_time=1, n=1, background=True)


### PR DESCRIPTION
Allows the strike release duration (the time during which the gate remains unlocked after triggering the strike) to be configured with an environment variable. Previously, this was hard-coded at three seconds.