### PR TITLE
If data cannot be fetched or set, exit the process

### DIFF
--- a/dingdongditch.service
+++ b/dingdongditch.service
@@ -6,6 +6,8 @@ After=multi-user.target
 Type=idle
 WorkingDirectory={{DIR}}
 ExecStart=/usr/bin/make run
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/dingdongditch/user_settings.py
+++ b/dingdongditch/user_settings.py
@@ -31,7 +31,7 @@ def get_data():
         logger.exception(
             'Could not load user settings from adapter "%s": %s', adapter.NAME, e
         )
-        return None
+        raise
 
 
 def set_data(key, data, root='settings'):
@@ -44,6 +44,7 @@ def set_data(key, data, root='settings'):
         logger.exception(
             'Could not set user settings with adapter "%s": %s', adapter.NAME, e
         )
+        raise
 
 
 def init_system_data():

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -34,9 +34,12 @@ def test_get_adapter__valid(settings):
 
 def test_get_data__error(adapter):
     adapter.get_settings.side_effect = TypeError
+    logger_mock = mocker.patch('dingdongditch.user_settings.logger')
 
-    result = user_settings.get_data()
-    assert result is None
+    with pytest.raises(TypeError):
+        user_settings.get_data()
+
+    assert logger_mock.exception.called
 
 
 def test_get_data__valid(adapter):
@@ -50,7 +53,8 @@ def test_set_data__error(adapter, mocker):
     adapter.set_data.side_effect = TypeError
     logger_mock = mocker.patch('dingdongditch.user_settings.logger')
 
-    user_settings.set_data('foo', 'bar')
+    with pytest.raises(TypeError):
+        user_settings.set_data('foo', 'bar')
 
     assert logger_mock.exception.called
 

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -32,7 +32,7 @@ def test_get_adapter__valid(settings):
     assert adapter is firebase_user_settings_adapter
 
 
-def test_get_data__error(adapter):
+def test_get_data__error(adapter, mocker):
     adapter.get_settings.side_effect = TypeError
     logger_mock = mocker.patch('dingdongditch.user_settings.logger')
 


### PR DESCRIPTION
In certain instances the process can get wedged. By raising an exception, the process will exit, and systemd will restart it.