### PR TITLE
Fixed blinked signal path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 node_modules
 .cache
 .firebaserc
+.pytest_cache

--- a/dingdongditch/firebase_user_settings_adapter.py
+++ b/dingdongditch/firebase_user_settings_adapter.py
@@ -37,6 +37,10 @@ def set_data(path, data, root=None):
     live_data.set_data(abs_path, data)
 
 
+def signal(*args, **kwargs):
+    live_data.signal(*args, **kwargs)
+
+
 def reset():
     live_data.reset()
 

--- a/dingdongditch/trigger.py
+++ b/dingdongditch/trigger.py
@@ -3,8 +3,6 @@ import functools
 import logging
 import signal
 
-import blinker
-
 from . import action, notifier, system_settings, user_settings
 
 WINDOW = datetime.timedelta(seconds=system_settings.BUZZER_INTERVAL)
@@ -71,7 +69,7 @@ def handle_gate_strike_unit_2(sender, value=None):
 if action.UNIT_1:
     action.UNIT_1.buzzer.when_held = trigger_unit_1
     action.UNIT_1.buzzer.when_pressed = lambda: logger.debug('Trigger pressed for unit 1')
-    blinker.signal(
+    user_settings.signal(
         get_strike_setting_path(action.UNIT_1.id)
     ).connect(handle_gate_strike_unit_1)
 
@@ -79,7 +77,7 @@ if action.UNIT_1:
 if action.UNIT_2:
     action.UNIT_2.buzzer.when_held = trigger_unit_2
     action.UNIT_2.buzzer.when_pressed = lambda: logger.debug('Trigger pressed for unit 2')
-    blinker.signal(
+    user_settings.signal(
         get_strike_setting_path(action.UNIT_2.id)
     ).connect(handle_gate_strike_unit_2)
 

--- a/dingdongditch/user_settings.py
+++ b/dingdongditch/user_settings.py
@@ -47,7 +47,7 @@ def set_data(key, data, root=None):
 
 
 def signal(*args, **kwargs):
-    adpater = get_adapter()
+    adapter = get_adapter()
     adapter.signal(*args, **kwargs)
 
 

--- a/dingdongditch/user_settings.py
+++ b/dingdongditch/user_settings.py
@@ -46,6 +46,11 @@ def set_data(key, data, root=None):
         raise
 
 
+def signal(*args, **kwargs):
+    adpater = self.get_adapter()
+    adapter.signal(*args, **kwargs)
+
+
 def init_system_data():
     data = {
         settings.UNIT_1.id: 1,

--- a/dingdongditch/user_settings.py
+++ b/dingdongditch/user_settings.py
@@ -47,7 +47,7 @@ def set_data(key, data, root=None):
 
 
 def signal(*args, **kwargs):
-    adpater = self.get_adapter()
+    adpater = get_adapter()
     adapter.signal(*args, **kwargs)
 
 

--- a/tests/test_firebase_user_settings_adapter.py
+++ b/tests/test_firebase_user_settings_adapter.py
@@ -38,6 +38,12 @@ class Test_set_data:
         live_data.set_data.assert_called_with('/settings/foo', data)
 
 
+def test_signal(live_data):
+    firebase_user_settings_adapter.signal('foo', bar='baz')
+
+    live_data.signal.assert_called_with('foo', bar='baz')
+
+
 def test_hangup(live_data):
     firebase_user_settings_adapter.hangup()
 

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -71,6 +71,12 @@ def test_set_data__custom_root(adapter):
     adapter.set_data.assert_called_with('foo', 'bar', 'baz')
 
 
+def test_signal(adapter):
+    user_settings.signal('foo', bar='baz')
+
+    adapter.signal.assert_called_with('foo', bar='baz')
+
+
 def test_init_system_data__single_unit(mocker, settings, set_data):
     settings(UNIT_1=mocker.Mock(id='1111'))
 


### PR DESCRIPTION
This got missed after the FirebaseLiveData refactor. Ensure the gate strike unlock signal is connected to the proper namespace that now lives on the LiveData instance.