### PR TITLE
Notify recipients concurrently

### DIFF
--- a/dingdongditch/notifier.py
+++ b/dingdongditch/notifier.py
@@ -136,7 +136,6 @@ def notify_recipients(unit_id):
     # True means the notification succeeded. False means it failed.
     failures = [not f.result() for f in futures.as_completed(all_futures)]
 
-
     # If all notifications failed, fallback to normal bell, if enabled
     if usr_unit.recipients and all(failures):
         logger.error('All notifications failed!')

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -229,3 +229,16 @@ def test__notify__recipient_type__unknown(mocker):
     assert log_mock.error.called
     assert not notify_by_phone_mock.called
     assert not notify_by_push_mock.called
+
+
+def test_notify_with_future(mocker):
+    executor_mock = mocker.patch('dingdongditch.notifier.executor')
+
+    notifier.notify_with_future('1234', 'asdf1234=', 2)
+
+    executor_mock.submit.assert_called_with(
+        notifier.notify,
+        '1234',
+        'asdf1234=',
+        2
+    )


### PR DESCRIPTION
Notify recipients using concurrent requests. This should speed up how quickly all recipients are notified.