### PR TITLE
Set lastSeenAt key in firebase after data updates

### DIFF
--- a/dingdongditch/system_settings.py
+++ b/dingdongditch/system_settings.py
@@ -126,6 +126,8 @@ FIREBASE_FCM_KEY = Env.string('DDD_FIREBASE_FCM_KEY')
 # Root path for user settings in adapter
 USER_SETTINGS_PATH = '/settings'
 
+# Path to system-level settings in adapter
+SYSTEM_SETTINGS_PATH = '/systemSettings'
 
 ##
 ## Unit configuration

--- a/dingdongditch/trigger.py
+++ b/dingdongditch/trigger.py
@@ -10,6 +10,7 @@ LAST_SEEN_AT_KEY = 'lastSeenAt'
 
 logger = logging.getLogger(__name__)
 
+
 def throttle(window):
     def wrapper(func):
         state = {

--- a/dingdongditch/trigger.py
+++ b/dingdongditch/trigger.py
@@ -6,8 +6,9 @@ import signal
 from . import action, notifier, system_settings, user_settings
 
 WINDOW = datetime.timedelta(seconds=system_settings.BUZZER_INTERVAL)
-logger = logging.getLogger(__name__)
+LAST_SEEN_AT_KEY = 'lastSeenAt'
 
+logger = logging.getLogger(__name__)
 
 def throttle(window):
     def wrapper(func):
@@ -66,6 +67,15 @@ def handle_gate_strike_unit_2(sender, value=None):
     user_settings.set_data(get_strike_setting_path(action.UNIT_2.id), 0, root='/')
 
 
+def get_last_updated_path():
+    return '{}/{}'.format(system_settings.SYSTEM_SETTINGS_PATH, LAST_SEEN_AT_KEY)
+
+
+def handle_last_updated():
+    user_settings.set_data(get_last_updated_path(), datetime.datetime.utcnow(), root='/')
+
+
+# Set up UNIT 1
 if action.UNIT_1:
     action.UNIT_1.buzzer.when_held = trigger_unit_1
     action.UNIT_1.buzzer.when_pressed = lambda: logger.debug('Trigger pressed for unit 1')
@@ -74,12 +84,17 @@ if action.UNIT_1:
     ).connect(handle_gate_strike_unit_1)
 
 
+# Set up UNIT 2
 if action.UNIT_2:
     action.UNIT_2.buzzer.when_held = trigger_unit_2
     action.UNIT_2.buzzer.when_pressed = lambda: logger.debug('Trigger pressed for unit 2')
     user_settings.signal(
         get_strike_setting_path(action.UNIT_2.id)
     ).connect(handle_gate_strike_unit_2)
+
+
+# Set last updated timestamp
+user_settings.signal(system_settings.USER_SETTINGS_PATH).connect(handle_last_updated)
 
 
 def run():

--- a/dingdongditch/user_settings.py
+++ b/dingdongditch/user_settings.py
@@ -57,7 +57,7 @@ def init_system_data():
     }
     if settings.UNIT_2.id:
         data[settings.UNIT_2.id] = 1
-    set_data('units', data, 'systemSettings')
+    set_data('units', data, settings.SYSTEM_SETTINGS_PATH)
 
 
 def init_user_data():

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,4 +1,16 @@
+from datetime import datetime
+
+import pytest
+
 from dingdongditch import system_settings, trigger
+
+
+@pytest.fixture
+def utcnow(mocker):
+    now = datetime.utcnow()
+    datetime_mock = mocker.patch('dingdongditch.trigger.datetime')
+    datetime_mock.datetime.utcnow.return_value = now
+    return now
 
 
 def test_trigger_unit_1(mocker):
@@ -19,3 +31,22 @@ def test_trigger_unit_2(mocker):
     trigger.trigger_unit_2()
 
     notify_mock.assert_called_with(2)
+
+
+def test_get_last_updated_path():
+    path = trigger.get_last_updated_path()
+
+    assert path == '/systemSettings/lastSeenAt'
+
+
+def test_handle_last_updated(mocker, utcnow):
+    mocker.patch('dingdongditch.trigger.get_last_updated_path').return_value = '/foo'
+    set_data_mock = mocker.patch('dingdongditch.user_settings.set_data')
+
+    trigger.handle_last_updated()
+
+    set_data_mock.assert_called_with(
+        '/foo',
+        utcnow,
+        root='/'
+    )

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -82,7 +82,7 @@ def test_init_system_data__single_unit(mocker, settings, set_data):
 
     user_settings.init_system_data()
 
-    set_data.assert_called_with('units', { '1111': 1}, 'systemSettings')
+    set_data.assert_called_with('units', { '1111': 1}, '/systemSettings')
 
 
 def test_init_system_data__dual_units(mocker, settings, set_data):
@@ -99,7 +99,7 @@ def test_init_system_data__dual_units(mocker, settings, set_data):
             '1111': 1,
             '2222': 1,
         },
-        'systemSettings'
+        '/systemSettings'
     )
 
 


### PR DESCRIPTION
Whenever updates are received, send back a timestamp indicating when that update was seen. This will enable better monitoring of connectivity errors in the app.